### PR TITLE
Rebuilds the topics actor into a reuseable class with Avro support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val VERSION_SCALA_TEST        = "3.1.2"
 lazy val VERSION_CASSANDRA         = "3.5.0"
 lazy val VERSION_AKKA_STREAM_KAFKA = "0.20"
 lazy val VERSION_SCALA_MOCK        = "4.1.0"
+lazy val VERSION_AVRO4S            = "1.9.0"
 
 lazy val meta = Seq(
   name := """services-execute""",
@@ -38,6 +39,7 @@ lazy val lib_deps = Seq(
   "org.mongodb.scala"      %% "mongo-scala-driver"      % VERSION_MONGO_SCALA,
   "com.typesafe.akka"      %% "akka-stream-kafka"       % VERSION_AKKA_STREAM_KAFKA,
   "com.datastax.cassandra" %  "cassandra-driver-core"   % VERSION_CASSANDRA,
+  "com.sksamuel.avro4s"    %% "avro4s-core"             % VERSION_AVRO4S,
   "org.scalamock"          %% "scalamock"               % VERSION_SCALA_MOCK % Test
 )
 

--- a/src/main/scala/org/xalgorithms/Main.scala
+++ b/src/main/scala/org/xalgorithms/Main.scala
@@ -28,19 +28,11 @@ import akka.pattern.gracefulStop
 import scala.concurrent._
 import scala.concurrent.duration._
 
-import org.xalgorithms.actors.TopicActor
+import org.xalgorithms.actors.ActionsActor
 import org.xalgorithms.streams.AkkaStreams
 
 object Main extends App with AkkaStreams {
   import org.xalgorithms.actors.Triggers._
-
-  class ActionsActor extends TopicActor("il.verify.rule_execution") {
-    def trigger(tr: Trigger): Unit = tr match {
-      case TriggerById(request_id) => {
-        _log.info(s"TriggerById(${request_id})")
-      }
-    }
-  }
 
   implicit val actor_system = ActorSystem("interlibr-service-execute")
   private val _log = Logging(actor_system, this.getClass())

--- a/src/main/scala/org/xalgorithms/Main.scala
+++ b/src/main/scala/org/xalgorithms/Main.scala
@@ -22,24 +22,42 @@
 // <http://www.gnu.org/licenses/>.
 package org.xalgorithms
 
-import akka.actor.{ ActorSystem, Props }
-import scala.concurrent.{ Await }
+import akka.actor._
+import akka.event.Logging
+import akka.pattern.gracefulStop
+import scala.concurrent._
 import scala.concurrent.duration._
 
-import org.xalgorithms.actors.ActionStream
+import org.xalgorithms.actors.TopicActor
 import org.xalgorithms.streams.AkkaStreams
-import org.xalgorithms.actors.Triggers.InitializeConsumer
 
 object Main extends App with AkkaStreams {
+  import org.xalgorithms.actors.Triggers._
+
+  class ActionsActor extends TopicActor("il.verify.rule_execution") {
+    def trigger(tr: Trigger): Unit = tr match {
+      case TriggerById(request_id) => {
+        _log.info(s"TriggerById(${request_id})")
+      }
+    }
+  }
+
   implicit val actor_system = ActorSystem("interlibr-service-execute")
+  private val _log = Logging(actor_system, this.getClass())
 
-  val actor_action_stream = actor_system.actorOf(Props(new ActionStream), "action_stream")
+  val actors = Map(
+    "verify_rule_execution" -> Props[ActionsActor]
+  ).map { case (name, props) => actor_system.actorOf(props, s"actors_${name}") }
 
-  actor_action_stream ! InitializeConsumer()
-
-  println(s"# setting up consumer (${actor_action_stream})")
+  println(s"# setting up consumers")
+  actors.foreach { ref => ref ! InitializeConsumer() }
 
   scala.sys.addShutdownHook({
+    println("# stopping actors")
+    actors.foreach { ref =>
+      Await.result(gracefulStop(ref, 2 seconds), 3.seconds)
+    }
+
     println("# shutdown")
     actor_system.terminate()
     Await.result(actor_system.whenTerminated, 10.seconds)

--- a/src/main/scala/org/xalgorithms/actors/ActionsActor.scala
+++ b/src/main/scala/org/xalgorithms/actors/ActionsActor.scala
@@ -22,12 +22,26 @@
 // <http://www.gnu.org/licenses/>.
 package org.xalgorithms.actors
 
+import scala.util.{ Success, Failure }
+
 import org.xalgorithms.actors.Triggers._
+import org.xalgorithms.services.{ AkkaLogger, Mongo, MongoActions }
 
 class ActionsActor extends TopicActor("il.verify.rule_execution") {
+  private val _mongo = new Mongo(new AkkaLogger("mongo", log))
+
   def trigger(tr: Trigger): Unit = tr match {
     case TriggerById(request_id) => {
       log.info(s"TriggerById(${request_id})")
+      _mongo.find_one(MongoActions.FindTestRunById(request_id)).onComplete {
+        case Success(doc) => {
+          println(doc)
+        }
+
+        case Failure(th) => {
+          println("failed")
+        }
+      }
     }
   }
 }

--- a/src/main/scala/org/xalgorithms/actors/ActionsActor.scala
+++ b/src/main/scala/org/xalgorithms/actors/ActionsActor.scala
@@ -1,0 +1,33 @@
+// Copyright (C) 2018 Don Kelly <karfai@gmail.com>
+
+// This file is part of Interlibr, a functional component of an
+// Internet of Rules (IoR).
+
+// ACKNOWLEDGEMENTS
+// Funds: Xalgorithms Foundation
+// Collaborators: Don Kelly, Joseph Potvin and Bill Olders.
+
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Affero General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public
+// License along with this program. If not, see
+// <http://www.gnu.org/licenses/>.
+package org.xalgorithms.actors
+
+import org.xalgorithms.actors.Triggers._
+
+class ActionsActor extends TopicActor("il.verify.rule_execution") {
+  def trigger(tr: Trigger): Unit = tr match {
+    case TriggerById(request_id) => {
+      log.info(s"TriggerById(${request_id})")
+    }
+  }
+}

--- a/src/main/scala/org/xalgorithms/actors/Messages.scala
+++ b/src/main/scala/org/xalgorithms/actors/Messages.scala
@@ -24,6 +24,10 @@ package org.xalgorithms.actors
 
 object Triggers {
   case class InitializeConsumer()
+  case class FailureDecode()
+
+  abstract class Trigger
+  case class TriggerById(id: String) extends Trigger
 }
 
 object Actions {

--- a/src/main/scala/org/xalgorithms/actors/TopicActor.scala
+++ b/src/main/scala/org/xalgorithms/actors/TopicActor.scala
@@ -37,7 +37,6 @@ import org.xalgorithms.actors.Actions._
 import org.xalgorithms.actors.Triggers._
 import org.xalgorithms.config.Settings
 import org.xalgorithms.streams.AkkaStreams
-import org.xalgorithms.services.Mongo
 
 abstract class TopicActor(topic: String) extends Actor with AkkaStreams with ActorLogging {
   implicit val actor_system = context.system
@@ -48,7 +47,6 @@ abstract class TopicActor(topic: String) extends Actor with AkkaStreams with Act
     .withGroupId(kafka_settings("group_id"))
     .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
     .withProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true")
-  val mongo = new Mongo()
 
   // TODO: research when committable source would be useful
   // https://github.com/akka/reactive-kafka/blob/master/core/src/main/scala/akka/kafka/scaladsl/Consumer.sca

--- a/src/main/scala/org/xalgorithms/services/Logger.scala
+++ b/src/main/scala/org/xalgorithms/services/Logger.scala
@@ -22,6 +22,8 @@
 // <http://www.gnu.org/licenses/>.
 package org.xalgorithms.services
 
+import akka.event.LoggingAdapter
+
 abstract class Logger {
   def debug(m: String)
   def error(m: String)
@@ -30,4 +32,9 @@ abstract class Logger {
 class LocalLogger extends Logger {
   def debug(m: String) = { println(s"# ${m}") }
   def error(m: String) = { println(s"! ${m}") }
+}
+
+class AkkaLogger(tag: String, akka_log: LoggingAdapter) extends Logger {
+  def debug(m: String) = { akka_log.debug(s"# (${tag}) ${m}") }
+  def error(m: String) = { akka_log.error(s"# (${tag}) ${m}") }
 }

--- a/src/main/scala/org/xalgorithms/services/Logger.scala
+++ b/src/main/scala/org/xalgorithms/services/Logger.scala
@@ -20,11 +20,14 @@
 // You should have received a copy of the GNU Affero General Public
 // License along with this program. If not, see
 // <http://www.gnu.org/licenses/>.
-package org.xalgorithms.config
+package org.xalgorithms.services
 
-object Settings {
-  val Kafka = Map(
-    "bootstrap_servers" -> sys.env.getOrElse("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
-    "group_id" -> "il-group-execute"
-  )
+abstract class Logger {
+  def debug(m: String)
+  def error(m: String)
+}
+
+class LocalLogger extends Logger {
+  def debug(m: String) = { println(s"# ${m}") }
+  def error(m: String) = { println(s"! ${m}") }
 }

--- a/src/main/scala/org/xalgorithms/services/Mongo.scala
+++ b/src/main/scala/org/xalgorithms/services/Mongo.scala
@@ -23,7 +23,6 @@
 package org.xalgorithms.services
 
 import java.util.UUID.randomUUID
-
 import org.mongodb.scala.bson.{ BsonDocument }
 import org.mongodb.scala._
 import org.mongodb.scala.model.Aggregates._
@@ -34,24 +33,89 @@ import org.mongodb.scala.model.Updates._
 import org.mongodb.scala.model._
 import scala.concurrent.{ Future, Promise }
 
-class Mongo(logger: Logger = new LocalLogger()) {
+// should use an actor's execution context
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object MongoActions {
+  abstract class Store() {
+    def document : Document
+    def id: String
+  }
+
+  case class StoreDocument(doc: BsonDocument) extends Store {
+    private val public_id = randomUUID.toString()
+
+    def document: Document = {
+      Document("public_id" -> public_id, "content" -> doc)
+    }
+
+    def id = public_id
+  }
+
+  case class StoreTestRun(rule_id: String, ctx: BsonDocument) extends Store {
+    private val request_id = randomUUID.toString()
+
+    def document: Document = {
+      Document("rule_id" -> rule_id, "request_id" -> request_id, "context" -> ctx)
+    }
+
+    def id = request_id
+  }
+
+  class FindOne()
+  case class FindByKey(cn: String, key: String, value: String) extends FindOne
+
+  object FindDocumentById {
+    def apply(id: String) = FindByKey("documents", "public_id", id)
+  }
+
+  object FindTestRunById {
+    def apply(id: String) = FindByKey("test-runs", "request_id", id)
+  }
+}
+
+class Mongo(log: Logger = new LocalLogger) {
   val url = sys.env.get("MONGO_URL").getOrElse("mongodb://127.0.0.1:27017/")
   val cl = MongoClient(url)
   val db = cl.getDatabase("xadf")
 
-  private def documents(): MongoCollection[Document] = {
-    db.getCollection("documents")
-  }
-
-  def find_one(collection: String, public_id: String): Future[BsonDocument] = {
+  def find_one(op: MongoActions.FindOne): Future[BsonDocument] = {
     val pr = Promise[BsonDocument]()
-    db.getCollection(collection).find(equal("public_id", public_id)).first().subscribe(
-      (doc: Document) => pr.success(doc.toBsonDocument)
-    )
+
+    op match {
+      case MongoActions.FindByKey(cn, key, value) => {
+        db.getCollection(cn).find(equal(key, value)).first().subscribe(
+          (doc: Document) => pr.success(doc.toBsonDocument)
+        )
+      }
+    }
+
     pr.future
   }
 
-  def find_document(public_id: String) = find_one("documents", public_id)
+  def store(op: MongoActions.Store): Future[String] = {
+    val pr = Promise[String]()
+    val cn = op match {
+      case MongoActions.StoreDocument(_) => "documents"
+      case MongoActions.StoreTestRun(_, _)  => "test-runs"
+    }
 
-  def find_rule(public_id: String) = find_one("rules", public_id)
+    db.getCollection(cn).insertOne(op.document).subscribe(new Observer[Completed] {
+      override def onComplete(): Unit = {
+        log.debug(s"insert completed")
+      }
+
+      override def onNext(res: Completed): Unit = {
+        log.debug(s"insert next")
+        pr.success(op.id)
+      }
+
+      override def onError(th: Throwable): Unit = {
+        log.error(s"failed insert, trigging promise")
+        pr.failure(th)
+      }
+    })
+
+    pr.future
+  }
 }

--- a/src/main/scala/org/xalgorithms/services/Mongo.scala
+++ b/src/main/scala/org/xalgorithms/services/Mongo.scala
@@ -1,0 +1,57 @@
+// Copyright (C) 2018 Don Kelly <karfai@gmail.com>
+
+// This file is part of Interlibr, a functional component of an
+// Internet of Rules (IoR).
+
+// ACKNOWLEDGEMENTS
+// Funds: Xalgorithms Foundation
+// Collaborators: Don Kelly, Joseph Potvin and Bill Olders.
+
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Affero General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public
+// License along with this program. If not, see
+// <http://www.gnu.org/licenses/>.
+package org.xalgorithms.services
+
+import java.util.UUID.randomUUID
+
+import org.mongodb.scala.bson.{ BsonDocument }
+import org.mongodb.scala._
+import org.mongodb.scala.model.Aggregates._
+import org.mongodb.scala.model.Filters._
+import org.mongodb.scala.model.Projections._
+import org.mongodb.scala.model.Sorts._
+import org.mongodb.scala.model.Updates._
+import org.mongodb.scala.model._
+import scala.concurrent.{ Future, Promise }
+
+class Mongo(logger: Logger = new LocalLogger()) {
+  val url = sys.env.get("MONGO_URL").getOrElse("mongodb://127.0.0.1:27017/")
+  val cl = MongoClient(url)
+  val db = cl.getDatabase("xadf")
+
+  private def documents(): MongoCollection[Document] = {
+    db.getCollection("documents")
+  }
+
+  def find_one(collection: String, public_id: String): Future[BsonDocument] = {
+    val pr = Promise[BsonDocument]()
+    db.getCollection(collection).find(equal("public_id", public_id)).first().subscribe(
+      (doc: Document) => pr.success(doc.toBsonDocument)
+    )
+    pr.future
+  }
+
+  def find_document(public_id: String) = find_one("documents", public_id)
+
+  def find_rule(public_id: String) = find_one("rules", public_id)
+}


### PR DESCRIPTION
Since the schedule service is now encoding messages with Avro[Json], we need to handle that in the execute service. This change also makes the ActionStream actor into the more reusable TopicActor: an actor that acts as the Sink of a flow coming in from a Kafka topic.